### PR TITLE
Fixed the issue that friend cannot jump to the chat list when sending messages

### DIFF
--- a/src/pages/Home/Friend/index.jsx
+++ b/src/pages/Home/Friend/index.jsx
@@ -140,7 +140,7 @@ export default function Friend() {
 
 
     const onSendMsgClick = (id, type) => {
-        ChatListApi.create({userId: id, type: type}).then(res => {
+        ChatListApi.create({toId: id, type: type}).then(res => {
             if (res.code === 0) {
                 dispatch(setCurrentChatId(id, res.data))
                 dispatch(setCurrentOption("chat"))


### PR DESCRIPTION
Changes proposed in this pull request:
- Code optimization

> Change the onSendMsgClick method parameter from userId to toId.